### PR TITLE
chore: add html lang attribute

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -1,3 +1,11 @@
+<script setup>
+useHead({
+  htmlAttrs: {
+    lang: 'en',
+  },
+})
+</script>
+
 <template>
   <NuxtPage />
   <p class="text-center py-6 text-sm">

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,7 +1,13 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   compatibilityDate: '2024-07-30',
-
+  app: {
+    head: {
+      htmlAttrs: {
+        lang: 'en'
+      }
+    }
+  },
   // https://nuxt.com/docs/getting-started/upgrade#testing-nuxt-4
   future: { compatibilityVersion: 4 },
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,6 +1,7 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   compatibilityDate: '2024-07-30',
+
   // https://nuxt.com/docs/getting-started/upgrade#testing-nuxt-4
   future: { compatibilityVersion: 4 },
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,13 +1,6 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   compatibilityDate: '2024-07-30',
-  app: {
-    head: {
-      htmlAttrs: {
-        lang: 'en'
-      }
-    }
-  },
   // https://nuxt.com/docs/getting-started/upgrade#testing-nuxt-4
   future: { compatibilityVersion: 4 },
 


### PR DESCRIPTION
This PR adds the lang attribute to the HTML tag to enhance accessibility. During a Lighthouse audit, it was noted that the accessibility score was slightly below 100, and one of the recommendations was to include the lang attribute in the HTML tag. 

![image](https://github.com/user-attachments/assets/d55823e8-3855-4b56-8092-ee082b905ad0)
