### PR TITLE
fix: update deprecated request

### DIFF
--- a/server/api/contributions.ts
+++ b/server/api/contributions.ts
@@ -17,6 +17,7 @@ export default defineCachedEventHandler(async (event) => {
     q: `type:pr+author:"${user.username}"`,
     per_page: 50,
     page: 1,
+    advanced_search: 'true',
   })
 
   // Filter out closed PRs that are not merged


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a540839a-3b57-465b-9c44-547b82a52aa7)
 
 WARN  [@octokit/request] "GET https://api.github.com/search/issues?q=type%3Apr+author%3A%22mancuoj%22&per_page=50&page=1" is deprecated. It is scheduled to be removed on Thu, 04 Sep 2025 00:00:00 GMT. See https://github.blog/changelog/2025-03-06-github-issues-projects-api-support-for-issues-advanced-search-and-more/