### PR TITLE
feat: support hiding PRs from private repos

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,4 @@
 NUXT_GITHUB_TOKEN=
 
 # Set to true to hide pull requests in private repositories
-NUXT_HIDE_PRIVATE_REPOS=
+HIDE_PRIVATE_REPOS=

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 # Create a GitHub token with no special scopes on https://github.com/settings/personal-access-tokens/new
 NUXT_GITHUB_TOKEN=
+
+# Set to true to hide pull requests in private repositories
+NUXT_HIDE_PRIVATE_REPOS=

--- a/server/api/contributions.ts
+++ b/server/api/contributions.ts
@@ -7,7 +7,7 @@ export default defineEventHandler(async () => {
     username: userResponse.data.login,
     avatar: userResponse.data.avatar_url,
   }
-  const hidePrivateRepos = process.env.NUXT_HIDE_PRIVATE_REPOS === 'true'
+  const hidePrivateRepos = process.env.HIDE_PRIVATE_REPOS === 'true'
   // Fetch pull requests from user
   const { data } = await octokit.request('GET /search/issues', {
     // To exclude the pull requests to your repositories

--- a/server/api/contributions.ts
+++ b/server/api/contributions.ts
@@ -7,12 +7,13 @@ export default defineEventHandler(async () => {
     username: userResponse.data.login,
     avatar: userResponse.data.avatar_url,
   }
+  const hidePrivateRepos = process.env.NUXT_HIDE_PRIVATE_REPOS === 'true'
   // Fetch pull requests from user
   const { data } = await octokit.request('GET /search/issues', {
     // To exclude the pull requests to your repositories
     // q: `type:pr+author:"${user.username}"+-user:"${user.username}"`,
     // To include the pull requests to your repositories
-    q: `type:pr+author:"${user.username}"`,
+    q: `type:pr+author:"${user.username}"${hidePrivateRepos ? '+is:public' : ''}`,
     per_page: 50,
     page: 1,
     advanced_search: 'true',


### PR DESCRIPTION
This PR adds an optional `NUXT_HIDE_PRIVATE_REPOS` env var that appends `is:public` to the GitHub search query, so PRs from private repos no longer appear on the public page.

Resolves #24